### PR TITLE
Properly show linting notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- Changed instance of AppSettingsState to nullable and added missing null checks.
+- Linting error notification is now properly shown.
+
+### Removed
+- Removed linting in the background.
 
 ## [0.0.10]
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 
 pluginGroup = com.github.blarc
 pluginName = GitlabTemplateLint
-pluginVersion = 0.0.10
+pluginVersion = 0.0.11
 
 # https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 212

--- a/src/main/kotlin/com/github/blarc/gitlab/template/lint/plugin/GitlabLintInspector.kt
+++ b/src/main/kotlin/com/github/blarc/gitlab/template/lint/plugin/GitlabLintInspector.kt
@@ -5,7 +5,6 @@ import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.components.service
-import com.intellij.openapi.progress.runBackgroundableTask
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiFile
 
@@ -15,18 +14,14 @@ class GitlabLintInspector : LocalInspectionTool() {
         return object : PsiElementVisitor() {
             override fun visitFile(file: PsiFile) {
                 if (Regex(".*gitlab-ci\\.(yaml|yml)$").matches(file.name)) {
-                    val gitlabToken = AppSettingsState.instance.gitlabToken
+                    val gitlabToken = AppSettingsState.instance?.gitlabToken
                     if (gitlabToken != null && gitlabToken.isNotEmpty()) {
                         val linter = file.project.service<GitlabLintRunner>()
-                        runBackgroundableTask("Linting Gitlab CI", file.project) {
-                            it.isIndeterminate = true
-                            val gitlabLintResponse = linter.run(file.text, file.virtualFile.path)
-
-                            if (gitlabLintResponse != null && !gitlabLintResponse.valid) {
-                                holder.registerProblem(
-                                    file, gitlabLintResponse.errors.toString(), ProblemHighlightType.ERROR
-                                )
-                            }
+                        val gitlabLintResponse = linter.run(file.text, file.virtualFile.path)
+                        if (gitlabLintResponse != null && !gitlabLintResponse.valid) {
+                            holder.registerProblem(
+                                file, gitlabLintResponse.errors.toString(), ProblemHighlightType.ERROR
+                            )
                         }
                     }
                 }

--- a/src/main/kotlin/com/github/blarc/gitlab/template/lint/plugin/GitlabLintRunner.kt
+++ b/src/main/kotlin/com/github/blarc/gitlab/template/lint/plugin/GitlabLintRunner.kt
@@ -39,8 +39,8 @@ class GitlabLintRunner(private val project: Project) {
                 getProjectId(remoteUrlString, gitlab).thenAccept { projectId ->
 
                     // Cache project id
-                    val remotesMap = AppSettingsState.instance.remotesMap
-                    if (!remotesMap.containsKey(remoteUrlString)) {
+                    val remotesMap = AppSettingsState.instance?.remotesMap
+                    if (remotesMap != null && !remotesMap.containsKey(remoteUrlString)) {
                         remotesMap[remoteUrlString] = projectId
                     }
 
@@ -70,8 +70,8 @@ class GitlabLintRunner(private val project: Project) {
     }
 
     private fun getProjectId(remoteUrl: String, gitlab: Gitlab) : CompletableFuture<Long> {
-        val remotesMap = AppSettingsState.instance.remotesMap
-        if (remotesMap.containsKey(remoteUrl)) {
+        val remotesMap = AppSettingsState.instance?.remotesMap
+        if (remotesMap != null && remotesMap.containsKey(remoteUrl)) {
             return CompletableFuture.completedFuture(remotesMap[remoteUrl])
         }
         return gitlab.searchProjectId(remoteUrl.removeSuffix(".git"))

--- a/src/main/kotlin/com/github/blarc/gitlab/template/lint/plugin/GitlabPostStartupActivity.kt
+++ b/src/main/kotlin/com/github/blarc/gitlab/template/lint/plugin/GitlabPostStartupActivity.kt
@@ -8,7 +8,7 @@ import com.intellij.openapi.startup.StartupActivity
 
 class GitlabPostStartupActivity: StartupActivity.Background {
     override fun runActivity(project: Project) {
-        val gitlabToken = AppSettingsState.instance.gitlabToken
+        val gitlabToken = AppSettingsState.instance?.gitlabToken
         if (gitlabToken == null || gitlabToken.isEmpty()) {
             NotificationGroupManager.getInstance()
                 .getNotificationGroup("GitlabLint")

--- a/src/main/kotlin/com/github/blarc/gitlab/template/lint/plugin/gitlab/GitlabFactory.kt
+++ b/src/main/kotlin/com/github/blarc/gitlab/template/lint/plugin/gitlab/GitlabFactory.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.project.Project
 class GitLabFactory() {
 
     fun getGitLab(url: String): Gitlab {
-        return Gitlab(url, AppSettingsState.instance.gitlabToken!!)
+        return Gitlab(url, AppSettingsState.instance?.gitlabToken!!)
     }
 
     companion object {

--- a/src/main/kotlin/com/github/blarc/gitlab/template/lint/plugin/listeners/GitlabLintFileEditorManagerListener.kt
+++ b/src/main/kotlin/com/github/blarc/gitlab/template/lint/plugin/listeners/GitlabLintFileEditorManagerListener.kt
@@ -17,7 +17,16 @@ class GitlabLintFileEditorManagerListener : FileEditorManagerListener {
 
         val project = event.manager.project
 
-        val matches = Regex(AppSettingsState.instance.gitlabLintRegexString).matches(event.newFile.name)
+        var regex = ".*gitlab-ci\\.(yaml|yml)$"
+        val appSettingsState = AppSettingsState.instance
+        if (appSettingsState?.gitlabLintRegexString != null) {
+            regex = appSettingsState.gitlabLintRegexString!!
+        }
+
+        var matches = false
+        if (event.newFile != null) {
+            matches = Regex(regex).matches(event.newFile.name)
+        }
 
         val lintStatusWidgetFactory = ApplicationManager.getApplication().getService<LintStatusWidgetFactory>()
         val statusBarWidgetSettings = ApplicationManager.getApplication().getService<StatusBarWidgetSettings>()

--- a/src/main/kotlin/com/github/blarc/gitlab/template/lint/plugin/settings/AppSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/blarc/gitlab/template/lint/plugin/settings/AppSettingsConfigurable.kt
@@ -27,20 +27,27 @@ class AppSettingsConfigurable : Configurable {
     }
 
     override fun isModified(): Boolean {
-        val settings: AppSettingsState = AppSettingsState.instance
-        return !appSettingsForm!!.gitlabToken.contentEquals(settings.gitlabToken?.toCharArray()) || appSettingsForm!!.gitlabRemotesTable.isModified(settings)
+        val settings = AppSettingsState.instance
+        if (settings != null) {
+            return !appSettingsForm!!.gitlabToken.contentEquals(settings.gitlabToken?.toCharArray()) || appSettingsForm!!.gitlabRemotesTable.isModified(settings)
+        }
+        return false
     }
 
     override fun apply() {
-        val settings: AppSettingsState = AppSettingsState.instance
-        settings.gitlabToken = String(appSettingsForm!!.gitlabToken!!)
-        appSettingsForm!!.gitlabRemotesTable.commit(settings)
+        val settings = AppSettingsState.instance
+        if (settings != null) {
+            settings.gitlabToken = String(appSettingsForm!!.gitlabToken!!)
+            appSettingsForm!!.gitlabRemotesTable.commit(settings)
+        }
     }
 
     override fun reset() {
-        val settings: AppSettingsState = AppSettingsState.instance
-        appSettingsForm!!.gitlabToken = settings.gitlabToken?.toCharArray()
-        appSettingsForm!!.gitlabRemotesTable.tableModel.remotesList = settings.remotesMap.toList().toMutableList()
+        val settings = AppSettingsState.instance
+        if (settings != null) {
+            appSettingsForm!!.gitlabToken = settings.gitlabToken?.toCharArray()
+            appSettingsForm!!.gitlabRemotesTable.tableModel.remotesList = settings.remotesMap.toList().toMutableList()
+        }
     }
 
     override fun disposeUIResources() {

--- a/src/main/kotlin/com/github/blarc/gitlab/template/lint/plugin/settings/AppSettingsState.kt
+++ b/src/main/kotlin/com/github/blarc/gitlab/template/lint/plugin/settings/AppSettingsState.kt
@@ -24,11 +24,11 @@ import org.jetbrains.annotations.Nullable
 class AppSettingsState : PersistentStateComponent<AppSettingsState> {
     companion object {
         const val SERVICE_NAME = "org.intellij.sdk.settings.com.github.blarc.gitlab.template.lint.plugin.settings.AppSettingsState"
-        val instance: AppSettingsState
+        val instance: AppSettingsState?
             get() = ApplicationManager.getApplication().getService(AppSettingsState::class.java)
     }
 
-    var gitlabLintRegexString: String = ".*gitlab-ci\\.(yaml|yml)$"
+    var gitlabLintRegexString: String? = ".*gitlab-ci\\.(yaml|yml)$"
 
     var gitlabToken: String?
         set(value) {


### PR DESCRIPTION
Changed AppSettingsState to nullable and added null checks.
Remove running linting in the background.
Check if file nullability in GitlabLintFileEditorManagerListener.

Closes #22 