### PR TITLE
Update links to get a new token from /profile to /user_settings

### DIFF
--- a/src/main/kotlin/com/github/blarc/gitlab/template/lint/plugin/settings/gitlabUrlToken/GitlabUrlTokenTable.kt
+++ b/src/main/kotlin/com/github/blarc/gitlab/template/lint/plugin/settings/gitlabUrlToken/GitlabUrlTokenTable.kt
@@ -140,7 +140,7 @@ class GitlabUrlTokenTable(val project: Project) {
                         } catch (e: Exception) {
                             "https://gitlab.com"
                         }
-                        BrowserLauncher.instance.open("$host/-/profile/personal_access_tokens?name=Gitlab+Template+Lint+token&scopes=api,read_api")
+                        BrowserLauncher.instance.open("$host/-/user_settings/personal_access_tokens?name=Gitlab+Template+Lint+token&scopes=api,read_api")
                     })
             }
             row {

--- a/src/main/resources/messages/MyBundle.properties
+++ b/src/main/resources/messages/MyBundle.properties
@@ -78,7 +78,7 @@ settings.gitlab-url-token.gitlab-url=Gitlab API URL
 settings.gitlab-url-token.gitlab-url.comment=Example: https://gitlab.example.com/api/v4.
 settings.gitlab-url-token.gitlab-token=Gitlab API token
 settings.gitlab-url-token.gitlab-token.comment=\
-  <p>You can get your token <a href="https://gitlab.com/-/profile/personal_access_tokens?name=Gitlab+Template+Lint+token&scopes=api,read_api">here.</a/></p>
+  <p>You can get your token <a href="https://gitlab.com/-/user_settings/personal_access_tokens?name=Gitlab+Template+Lint+token&scopes=api,read_api">here.</a/></p>
 settings.frequency.label=Lint frequency
 settings.frequency.on-change=On Change
 settings.frequency.on-save=On Save
@@ -123,4 +123,3 @@ lint.error.explanation=Explanation
 settings.ignored-errors.group.title=Ignored Errors
 settings.ignored-error.file=File
 settings.ignored-error.message=Error Message
-


### PR DESCRIPTION
Not sure if this is a breaking change for self-hosted Gitlab versions, but for hosted the /profile URL now returns 404. The new URL works in the same way and populates name and scopes correctly.